### PR TITLE
fix warning: change variable to immutable

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -8,7 +8,7 @@ const SIZE: f32 = 17.0;
 pub fn main() {
     // Loading and rasterization
     let font = include_bytes!("../resources/Roboto-Regular.ttf") as &[u8];
-    let mut font = fontdue::Font::from_bytes(font).unwrap();
+    let font = fontdue::Font::from_bytes(font).unwrap();
     let (metrics, bitmap) = font.rasterize(CHARACTER, SIZE);
 
     // Output


### PR DESCRIPTION
example was producing compile warnings using rustc 1.37.0 (eae3437df 2019-08-13)

fixed by changing `font` to immutable