### PR TITLE
Support configuring the output buffer format

### DIFF
--- a/examples/simple_rgb.rs
+++ b/examples/simple_rgb.rs
@@ -1,0 +1,18 @@
+use std::fs::File;
+use std::io::Write;
+
+// Scratch pad for glyphs: ⅞ g
+const CHARACTER: char = 'g';
+const SIZE: f32 = 50.0;
+
+pub fn main() {
+    // Loading and rasterization
+    let font = include_bytes!("../resources/Roboto-Regular.ttf") as &[u8];
+    let font = fontdue::Font::from_bytes(font, fontdue::FontSettings{ flip_vertical: false, buffer_kind: fontdue::Format::Rgb24 }).unwrap();
+    let (metrics, bitmap) = font.rasterize(CHARACTER, SIZE);
+
+    // Output
+    let mut o = File::create("fontdue.ppm").unwrap();
+    let _ = o.write(format!("P6\n{} {}\n255\n", metrics.width, metrics.height).as_bytes());
+    let _ = o.write(&bitmap);
+}

--- a/examples/simple_rgba.rs
+++ b/examples/simple_rgba.rs
@@ -1,0 +1,18 @@
+use std::fs::File;
+use std::io::Write;
+
+// Scratch pad for glyphs: ⅞ g
+const CHARACTER: char = 'g';
+const SIZE: f32 = 50.0;
+
+pub fn main() {
+    // Loading and rasterization
+    let font = include_bytes!("../resources/Roboto-Regular.ttf") as &[u8];
+    let font = fontdue::Font::from_bytes(font, fontdue::FontSettings{ flip_vertical: false, buffer_kind: fontdue::Format::Rgba32 }).unwrap();
+    let (metrics, bitmap) = font.rasterize(CHARACTER, SIZE);
+
+    // Output
+    let mut o = File::create("fontdue.pam").unwrap();
+    let _ = o.write(format!("P7\nWIDTH {}\nHEIGHT {}\nDEPTH 4\nMAXVAL 255\nTUPLTYPE RGB_ALPHA\nENDHDR\n", metrics.width, metrics.height).as_bytes());
+    let _ = o.write(&bitmap);
+}

--- a/src/font.rs
+++ b/src/font.rs
@@ -2,6 +2,7 @@ use crate::math::*;
 use crate::raster::Raster;
 use crate::raw::RawFont;
 use crate::FontResult;
+use crate::Format;
 use alloc::vec::*;
 use core::ops::Deref;
 use hashbrown::HashMap;
@@ -53,12 +54,14 @@ impl Glyph {
 pub struct FontSettings {
     /// Transforms all glyphs to be flipped vertically. False by default.
     pub flip_vertical: bool,
+    pub buffer_kind: Format,
 }
 
 impl Default for FontSettings {
     fn default() -> FontSettings {
         FontSettings {
             flip_vertical: false,
+            buffer_kind: Format::A8,
         }
     }
 }
@@ -73,6 +76,7 @@ pub struct Font {
     new_line_height: f32,
     has_horizontal_metrics: bool,
     has_vertical_metrics: bool,
+    settings: FontSettings,
 }
 
 impl Font {
@@ -133,6 +137,7 @@ impl Font {
             new_line_width,
             has_horizontal_metrics,
             has_vertical_metrics,
+            settings,
         })
     }
 
@@ -192,7 +197,7 @@ impl Font {
         let metrics = glyph.metrics(scale);
         let mut canvas = Raster::new(metrics.width, metrics.height);
         canvas.draw(&glyph.polygons, scale);
-        (metrics, canvas.get_bitmap())
+        (metrics, canvas.get_bitmap(self.settings.buffer_kind))
     }
 
     /// Finds the internal glyph index for the given character. If the character is not present in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub mod raw;
 mod simd;
 mod table;
 
+pub use raster::Format;
+
 pub use crate::font::*;
 
 /// Alias for Result<T, &'static str>.

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -74,7 +74,7 @@ impl Raster {
         Raster {
             w,
             h,
-            a: vec![0.0; w * h + 3],
+            a: vec![0.0; w * h + 15],
         }
     }
 
@@ -179,7 +179,7 @@ impl Raster {
             Format::Rgb24 => 3,
             Format::Rgba32 => 4,
         };
-        let aligned_length = (length + 3) & !3;
+        let aligned_length = (length + 15) & !15;
         let buf_size = aligned_length * width_multiplier;
         assert!(buf_size <= (self.a.len() * width_multiplier));
         // Turns out zeroing takes a while on very large sizes.

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -41,7 +41,7 @@ unsafe fn set_rgba32(output: &mut Vec<u8>, index: usize, value: u8) {
     *(output.get_unchecked_mut(start)) = value;
     *(output.get_unchecked_mut(start + 1)) = value;
     *(output.get_unchecked_mut(start + 2)) = value;
-    *(output.get_unchecked_mut(start + 3)) = if value == 0 { 0 } else { 255 };
+    *(output.get_unchecked_mut(start + 3)) = value;
 }
 
 #[inline(always)]

--- a/tests/letter_render_tests.rs
+++ b/tests/letter_render_tests.rs
@@ -1,4 +1,4 @@
-use fontdue::{Font, FontSettings};
+use fontdue::{Font, FontSettings, Format};
 
 const CHAR_SIZE: f32 = 17.0;
 
@@ -7,13 +7,13 @@ const ROBOTO_MONO_REGULAR_TTF: &[u8] = include_bytes!("../resources/RobotoMono-R
 const LIBERATION_SERIF_REGULAR: &[u8] = include_bytes!("../resources/LiberationSerif-Regular.ttf");
 
 // Performs some basic asserts on the rasterization output.
-fn check_best_guess_rasterization((metrics, bitmap): (fontdue::Metrics, Vec<u8>), rendered_char: char) {
+fn check_best_guess_rasterization((metrics, bitmap): (fontdue::Metrics, Vec<u8>), rendered_char: char, bitdepth: usize) {
     // Ensure this encompasses non-zero area
     assert!(metrics.width > 0, "width must be non-zero for character '{}'", rendered_char);
     assert!(metrics.height > 0, "height must be non-zero for character '{}'", rendered_char);
     // Ensure that the bitmap dimensions matches the metrics' description
     assert_eq!(
-        metrics.width * metrics.height,
+        metrics.width * metrics.height * (bitdepth / 8),
         bitmap.len(),
         "bitmap must match dimensions for character '{}'",
         rendered_char
@@ -27,7 +27,7 @@ fn render_roboto_characters() {
     let font = Font::from_bytes(ROBOTO_REGULAR_TTF, FontSettings::default()).unwrap();
 
     for chr in &['a', '1', '2', '#', '?', '█', '▒', '¾', 'æ'] {
-        check_best_guess_rasterization(font.rasterize(*chr, CHAR_SIZE), *chr);
+        check_best_guess_rasterization(font.rasterize(*chr, CHAR_SIZE), *chr, 8);
     }
 }
 
@@ -36,7 +36,25 @@ fn render_roboto_mono_characters() {
     let font = Font::from_bytes(ROBOTO_MONO_REGULAR_TTF, FontSettings::default()).unwrap();
 
     for chr in &['a', '1', '2', '#', '?', 'æ'] {
-        check_best_guess_rasterization(font.rasterize(*chr, CHAR_SIZE), *chr);
+        check_best_guess_rasterization(font.rasterize(*chr, CHAR_SIZE), *chr, 8);
+    }
+}
+
+#[test]
+fn render_roboto_mono_characters_rgb() {
+    let font = Font::from_bytes(ROBOTO_MONO_REGULAR_TTF, FontSettings{ buffer_kind: Format::Rgb24, flip_vertical: false }).unwrap();
+
+    for chr in &['a', '1', '2', '#', '?', 'æ'] {
+        check_best_guess_rasterization(font.rasterize(*chr, CHAR_SIZE), *chr, 24);
+    }
+}
+
+#[test]
+fn render_roboto_mono_characters_rgba() {
+    let font = Font::from_bytes(ROBOTO_MONO_REGULAR_TTF, FontSettings{ buffer_kind: Format::Rgba32, flip_vertical: false }).unwrap();
+
+    for chr in &['a', '1', '2', '#', '?', 'æ'] {
+        check_best_guess_rasterization(font.rasterize(*chr, CHAR_SIZE), *chr, 32);
     }
 }
 
@@ -45,6 +63,6 @@ fn render_liberation_serif_characters() {
     let font = Font::from_bytes(LIBERATION_SERIF_REGULAR, FontSettings::default()).unwrap();
 
     for chr in &['a', '1', '2', '#', '?', '█', '▒', '¾', 'æ'] {
-        check_best_guess_rasterization(font.rasterize(*chr, CHAR_SIZE), *chr);
+        check_best_guess_rasterization(font.rasterize(*chr, CHAR_SIZE), *chr, 8);
     }
 }


### PR DESCRIPTION
Provides a basic framework for the output formats requested in [this comment](https://github.com/mooman219/fontdue/issues/1#issuecomment-585034608).

Even with the vectorization intrinsics~

You might have a better idea for how to do this in the most efficient way possible - I was thinking something like const generics, but those are still unstable.

Also, it's _maybe_ useful in pretty much any non-trivial usecase to pass in an arbitrary buffer to render onto (specifying canvas format, height, width, and render starting position); this way I can just compose many calls into one buffer, without wasting time blitting stuff from all these tiny buffers into the big one (that'd mean adding into the base color already on the grid, but... w/e). For the same reason, being able to invert the black/white would be good, too (or just configurable stroke color in general).