### PR TITLE
Add header table info to font struct

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -45,8 +45,14 @@ impl AABB {
 /// Header table
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Hea {
+    /// The highest point that any glyph in the font extends to above the
+    /// baseline. Typically positive.
     pub ascent: f32,
+    /// The lowest point that any glyph in the font extends to below the
+    /// baseline. Typically negative.
     pub descent: f32,
+    /// The gap to leave between the descent of one line and the ascent of the
+    /// next. This is of course only a guideline given by the font's designers.
     pub line_gap: f32,
 }
 


### PR DESCRIPTION
Add header table info to font struct to help layout text.

(The algorithm is similar to https://github.com/redox-os/rusttype/blob/1346e49673127f6698053148da572c5e2e5fc3b9/dev/examples/gpu_cache.rs#L21)


https://github.com/mooman219/fontdue/issues/10#issuecomment-604225526