### PR TITLE
Fix trunc() in f32x4 impl

### DIFF
--- a/src/platform/simd_core.rs
+++ b/src/platform/simd_core.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 
+use crate::platform::float::trunc;
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
@@ -57,7 +58,7 @@ impl f32x4 {
 
     #[inline(always)]
     pub fn trunc(self) -> Self {
-        Self::new(self.x0.trunc(), self.x1.trunc(), self.x2.trunc(), self.x3.trunc())
+        Self::new(trunc(self.x0), trunc(self.x1), trunc(self.x2), trunc(self.x3))
     }
 }
 


### PR DESCRIPTION
Hello !

I am here to report another small issue when using fontdue 0.1.0 on a `#[no_std]` crate.

While the previous issue with hashbrown is fixed, the crate still does not compile in `#[no_std]` environments.

Here is the relevant error :

```
error[E0599]: no method named `trunc` found for type `f32` in the current scope
  --> /home/guillaume/.cargo/registry/src/github.com-1ecc6299db9ec823/fontdue-0.1.0/src/platform/simd_core.rs:60:27
   |
60 |         Self::new(self.x0.trunc(), self.x1.trunc(), self.x2.trunc(), self.x3.trunc())
   |                           ^^^^^ method not found in `f32`

error[E0599]: no method named `trunc` found for type `f32` in the current scope
  --> /home/guillaume/.cargo/registry/src/github.com-1ecc6299db9ec823/fontdue-0.1.0/src/platform/simd_core.rs:60:44
   |
60 |         Self::new(self.x0.trunc(), self.x1.trunc(), self.x2.trunc(), self.x3.trunc())
   |                                            ^^^^^ method not found in `f32`

error[E0599]: no method named `trunc` found for type `f32` in the current scope
  --> /home/guillaume/.cargo/registry/src/github.com-1ecc6299db9ec823/fontdue-0.1.0/src/platform/simd_core.rs:60:61
   |
60 |         Self::new(self.x0.trunc(), self.x1.trunc(), self.x2.trunc(), self.x3.trunc())
   |                                                             ^^^^^ method not found in `f32`

error[E0599]: no method named `trunc` found for type `f32` in the current scope
  --> /home/guillaume/.cargo/registry/src/github.com-1ecc6299db9ec823/fontdue-0.1.0/src/platform/simd_core.rs:60:78
   |
60 |         Self::new(self.x0.trunc(), self.x1.trunc(), self.x2.trunc(), self.x3.trunc())
   |                                                                              ^^^^^ method not found in `f32`
```

Weird, this should not have compiled in `std` crates, but it does !

It seems like `.trunc()` is still used, even after the local implementation in `src/platform/float.rs`.

I fixed the issue simply by replacing the problematic `x.trunc()` by `trunc(x)`, after a necessary `use crate::platform::float::trunc;` import statement.

Hope this helps !

Marime Gui