### PR TITLE
Add feature simd to enable or disable SIMD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ exclude = ["resources/**", "examples/**", "fontdue.pgm"]
 maintenance = { status = "experimental" }
 
 [features]
+default = ["simd"]
+simd = []
 # Enable this flag to include the freetype benchmark in the benches.
 freetype_benchmark = ["freetype-rs"]
 

--- a/src/platform/float/as_i32.rs
+++ b/src/platform/float/as_i32.rs
@@ -1,10 +1,10 @@
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 #[inline(always)]
 pub fn as_i32(value: f32) -> i32 {
     value as i32
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 #[inline(always)]
 pub fn as_i32(value: f32) -> i32 {
     #[cfg(target_arch = "x86")]

--- a/src/platform/float/ceil.rs
+++ b/src/platform/float/ceil.rs
@@ -1,5 +1,5 @@
 // [See license/rust-lang/libm] Copyright (c) 2018 Jorge Aparicio
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 pub fn ceil(x: f32) -> f32 {
     let mut ui = x.to_bits();
     let e = (((ui >> 23) & 0xff).wrapping_sub(0x7f)) as i32;
@@ -25,7 +25,7 @@ pub fn ceil(x: f32) -> f32 {
     f32::from_bits(ui)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 #[inline(always)]
 pub fn ceil(mut value: f32) -> f32 {
     #[cfg(target_arch = "x86")]

--- a/src/platform/float/floor.rs
+++ b/src/platform/float/floor.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 // [See license/rust-lang/libm] Copyright (c) 2018 Jorge Aparicio
 pub fn floor(x: f32) -> f32 {
     let mut ui = x.to_bits();
@@ -26,7 +26,7 @@ pub fn floor(x: f32) -> f32 {
     f32::from_bits(ui)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 #[inline(always)]
 pub fn floor(mut value: f32) -> f32 {
     #[cfg(target_arch = "x86")]

--- a/src/platform/float/fract.rs
+++ b/src/platform/float/fract.rs
@@ -1,10 +1,10 @@
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 #[inline(always)]
 pub fn fract(value: f32) -> f32 {
     value - super::trunc(value)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 #[inline(always)]
 pub fn fract(value: f32) -> f32 {
     #[cfg(target_arch = "x86")]

--- a/src/platform/float/get_bitmap.rs
+++ b/src/platform/float/get_bitmap.rs
@@ -1,10 +1,10 @@
 use alloc::vec::*;
-#[cfg(target_arch = "x86")]
+#[cfg(all(target_arch = "x86", feature = "simd"))]
 use core::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "simd"))]
 use core::arch::x86_64::*;
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 pub fn get_bitmap(a: &Vec<f32>, length: usize) -> Vec<u8> {
     use alloc::vec;
     let mut height = 0.0;
@@ -19,7 +19,7 @@ pub fn get_bitmap(a: &Vec<f32>, length: usize) -> Vec<u8> {
     output
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 pub fn get_bitmap(a: &Vec<f32>, length: usize) -> Vec<u8> {
     let aligned_length = (length + 3) & !3;
     assert!(aligned_length <= a.len());
@@ -60,7 +60,7 @@ pub fn get_bitmap(a: &Vec<f32>, length: usize) -> Vec<u8> {
 }
 
 // AVX is just slower, likely a bad impl.
-// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+// #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 // pub fn get_bitmap(a: &Vec<f32>, length: usize) -> Vec<u8> {
 //     let aligned_length = (length + 7) & !7;
 //     assert!(aligned_length <= a.len());

--- a/src/platform/float/sqrt.rs
+++ b/src/platform/float/sqrt.rs
@@ -1,5 +1,5 @@
 // [See license/rust-lang/libm] Copyright (c) 2018 Jorge Aparicio
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 pub fn sqrt(x: f32) -> f32 {
     const TINY: f32 = 1.0e-30;
 
@@ -84,7 +84,7 @@ pub fn sqrt(x: f32) -> f32 {
     f32::from_bits(ix as u32)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 #[inline(always)]
 pub fn sqrt(value: f32) -> f32 {
     #[cfg(target_arch = "x86")]

--- a/src/platform/float/trunc.rs
+++ b/src/platform/float/trunc.rs
@@ -1,5 +1,5 @@
 // [See license/rust-lang/libm] Copyright (c) 2018 Jorge Aparicio
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 pub fn trunc(x: f32) -> f32 {
     let mut i: u32 = x.to_bits();
     let mut e: i32 = (i >> 23 & 0xff) as i32 - 0x7f + 9;
@@ -18,7 +18,7 @@ pub fn trunc(x: f32) -> f32 {
     f32::from_bits(i)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 #[inline(always)]
 pub fn trunc(value: f32) -> f32 {
     #[cfg(target_arch = "x86")]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,11 +1,11 @@
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 mod simd_core;
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), not(feature = "simd")))]
 pub use simd_core::*;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 mod simd_x86;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 pub use simd_x86::*;
 
 mod float;


### PR DESCRIPTION
I'm writing a kernel that use fontdue to draw text on screen.
But fontdue use SSE on x86_64, and it's a bad idea to use SIMD in kernel: https://os.phil-opp.com/disable-simd/
So a feature to disable SIMD.