### PR TITLE
Attach user data to glyph layout structs

### DIFF
--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,5 +1,10 @@
 use fontdue::layout::{CoordinateSystem, Layout, LayoutSettings, TextStyle};
 
+#[derive(Debug)]
+struct UserData {
+    color: (f32, f32, f32, f32),
+}
+
 // cargo run --example layout --release
 pub fn main() {
     let font = include_bytes!("../resources/fonts/Roboto-Regular.ttf") as &[u8];
@@ -11,6 +16,36 @@ pub fn main() {
     };
     let fonts = &[roboto_regular];
     let styles = &[&TextStyle::new("Hello ", 35.0, 0), &TextStyle::new("world!", 40.0, 0)];
+    layout.layout_horizontal(fonts, styles, &settings, &mut output);
+
+    for glyph in output {
+        println!("{:?}", glyph);
+    }
+
+    // Once more, with user data
+    println!();
+    println!("User data version:");
+
+    let styles = &[
+        &TextStyle::with_user_data(
+            "Hello ",
+            35.0,
+            0,
+            UserData {
+                color: (1.0, 1.0, 1.0, 1.0),
+            },
+        ),
+        &TextStyle::with_user_data(
+            "world!",
+            40.0,
+            0,
+            UserData {
+                color: (0.0, 0.0, 0.0, 0.0),
+            },
+        ),
+    ];
+
+    let mut output = Vec::new();
     layout.layout_horizontal(fonts, styles, &settings, &mut output);
 
     for glyph in output {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -146,8 +146,6 @@ pub struct GlyphPosition<U> {
     pub width: usize,
     /// The height of the glyph. Dimensions are in pixels.
     pub height: usize,
-    /// The index of the TextStyle used for this glyph's layout.
-    pub text_style_index: usize,
     /// Custom user data attached to the TextStyle used for this glyph.
     pub user_data: U,
 }
@@ -286,7 +284,7 @@ impl Layout {
         };
         let mut current_ascent = 0.0; // Ascent for the current style.
         let mut current_new_line_size = 0.0; // New line height for the current style.
-        for (index, style) in styles.iter().enumerate() {
+        for style in styles {
             let mut byte_offset = 0;
             let font = &fonts[style.font_index];
             if let Some(metrics) = font.borrow().horizontal_line_metrics(style.px) {
@@ -340,7 +338,6 @@ impl Layout {
                         y,
                         width: metrics.width,
                         height: metrics.height,
-                        text_style_index: index,
                         user_data: &style.user_data,
                     });
                 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -133,7 +133,7 @@ impl Eq for GlyphRasterConfig {}
 
 /// A positioned scaled glyph.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct GlyphPosition {
+pub struct GlyphPosition<U> {
     /// Hashable key that can be used to uniquely identify a rasterized glyph.
     pub key: GlyphRasterConfig,
     /// The left side of the glyph bounding box. Dimensions are in pixels, and are alawys whole
@@ -146,16 +146,22 @@ pub struct GlyphPosition {
     pub width: usize,
     /// The height of the glyph. Dimensions are in pixels.
     pub height: usize,
+    /// The index of the TextStyle used for this glyph's layout.
+    pub text_style_index: usize,
+    /// Custom user data attached to the TextStyle used for this glyph.
+    pub user_data: U,
 }
 
 /// A style description for a segment of text.
-pub struct TextStyle<'a> {
+pub struct TextStyle<'a, U = ()> {
     /// The text to layout.
     pub text: &'a str,
     /// The scale of the text in pixel units.
     pub px: f32,
     /// The font to layout the text in.
     pub font_index: usize,
+    /// Custom user data to reference later in the `GlyphPosition` struct.
+    pub user_data: U,
 }
 
 impl<'a> TextStyle<'a> {
@@ -164,6 +170,18 @@ impl<'a> TextStyle<'a> {
             text,
             px,
             font_index,
+            user_data: (),
+        }
+    }
+}
+
+impl<'a, U> TextStyle<'a, U> {
+    pub fn with_user_data(text: &'a str, px: f32, font_index: usize, user_data: U) -> TextStyle<'a, U> {
+        TextStyle {
+            text,
+            px,
+            font_index,
+            user_data,
         }
     }
 }
@@ -237,12 +255,12 @@ impl Layout {
     /// Characters from the input string can only be omitted from the output, they are never
     /// reordered. The output buffer will always contain characters in the order they were defined
     /// in the styles.
-    pub fn layout_horizontal<T: Borrow<Font>>(
+    pub fn layout_horizontal<'a, T: Borrow<Font>, U>(
         &mut self,
         fonts: &[T],
-        styles: &[&TextStyle],
+        styles: &'a [&TextStyle<U>],
         settings: &LayoutSettings,
-        output: &mut Vec<GlyphPosition>,
+        output: &mut Vec<GlyphPosition<&'a U>>,
     ) {
         // Reset internal buffers.
         unsafe {
@@ -268,7 +286,7 @@ impl Layout {
         };
         let mut current_ascent = 0.0; // Ascent for the current style.
         let mut current_new_line_size = 0.0; // New line height for the current style.
-        for style in styles {
+        for (index, style) in styles.iter().enumerate() {
             let mut byte_offset = 0;
             let font = &fonts[style.font_index];
             if let Some(metrics) = font.borrow().horizontal_line_metrics(style.px) {
@@ -281,6 +299,7 @@ impl Layout {
                     next_line.new_line_size = current_new_line_size;
                 }
             }
+
             while byte_offset < style.text.len() {
                 let character = read_utf8(style.text, &mut byte_offset);
                 let linebreak_state = linebreak_property(&mut state, character) & wrap_mask;
@@ -321,6 +340,8 @@ impl Layout {
                         y,
                         width: metrics.width,
                         height: metrics.height,
+                        text_style_index: index,
+                        user_data: &style.user_data,
                     });
                 }
                 caret_x += advance;


### PR DESCRIPTION
From #43

This is some experimental code from what I discussed in the issue. I added both approaches in this code but really only one solution is sufficient:

* An index which points to the `TextStyle` a particular `GlyphPosition` came from
or
* A reference to custom user data on the `TextStyle` struct

Note: the way I implemented it, `GlyphPosition` will have an extra field the size of a reference (8 bytes typically) for the user data. I don't know if this is a dealbreaker for you or not. There may be a way to make that go away if you opt to not supply user data, [this article](https://ferrous-systems.com/blog/zero-sized-references/) may have some hints.

Let me know what you think!