### PR TITLE
Fixed vertical alignment for positive y down layouts

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -342,7 +342,7 @@ impl Layout {
         let mut current_ascent;
         let mut current_new_line_size;
         let mut x_base = settings.x;
-        let mut y_base = settings.y - Self::vertical_padding(settings, total_height);
+        let mut y_base = settings.y - ymod * Self::vertical_padding(settings, total_height);
         let line = self.line_metrics[0];
         next_line_index = line.end_index;
         current_ascent = ymod * line.ascent;


### PR DESCRIPTION
For layouts with `PositiveYDown`, only `VerticalAlign::Top` works as expected due to the `y_base` not taking the flipped `ymod` into account resulting in the font being laid out much further up that it should.

Tested that all `VerticalAlign` variants now work as expected.