### PR TITLE
Subpixel raster method and terminal example

### DIFF
--- a/examples/raster-print.rs
+++ b/examples/raster-print.rs
@@ -1,0 +1,33 @@
+
+const CHARACTER: char = 'b';
+const SIZE: f32 = 20.0;
+
+pub fn main() {
+    let font = include_bytes!("../resources/fonts/Roboto-Regular.ttf") as &[u8];
+    let settings = fontdue::FontSettings {
+        scale: SIZE,
+        ..fontdue::FontSettings::default()
+    };
+    let font = fontdue::Font::from_bytes(font, settings).unwrap();
+
+    println!("Normal:");
+    let (metrics, bitmap) = font.rasterize(CHARACTER, SIZE);
+    for y in 0 .. metrics.height {
+        for x in 0 .. metrics.width {
+            let char_s = bitmap[x + y * metrics.width];
+            print!("\x1B[48;2;{};{};{}m   ", char_s, char_s, char_s);
+        }
+        println!("\x1B[0m");
+    }
+    println!("\nSubpixel:");
+    let (metrics, bitmap) = font.rasterize_subpixel(CHARACTER, SIZE);
+    for y in 0 .. metrics.height {
+        for x in (0 .. metrics.width * 3).step_by(3) {
+            let char_r = bitmap[x + y * metrics.width * 3];
+            let char_g = bitmap[x + 1 + y * metrics.width * 3];
+            let char_b = bitmap[x + 2 + y * metrics.width * 3];
+            print!("\x1B[48;2;{};{};{}m   ", char_r, char_g, char_b);
+        }
+        println!("\x1B[0m");
+    }
+}

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -25,9 +25,9 @@ impl Raster {
         }
     }
 
-    pub(crate) fn draw(&mut self, glyph: &Glyph, scale: f32, offset_x: f32, offset_y: f32) {
-        let params = f32x4::new(1.0 / scale, 1.0 / scale, scale, scale);
-        let scale = f32x4::splat(scale);
+    pub(crate) fn draw(&mut self, glyph: &Glyph, scale_x: f32, scale_y: f32, offset_x: f32, offset_y: f32) {
+        let params = f32x4::new(1.0 / scale_x, 1.0 / scale_y, scale_x, scale_y);
+        let scale = f32x4::new(scale_x, scale_y, scale_x, scale_y);
         let offset = f32x4::new(offset_x, offset_y, offset_x, offset_y);
         for line in &glyph.v_lines {
             self.v_line(line, line.coords * scale + offset);


### PR DESCRIPTION
Adds a simple subpixel rasterization method that multiples the horizontal resolution by 3. The returned format is still valid for input into any texel analyser.

I also added a terminal example for testing, which removes necessity for creating an RGB format. Here is the result on Windows Terminal:
![image](https://user-images.githubusercontent.com/16048450/100957860-05e08280-34fa-11eb-93b2-a947e12e139b.png)
