### PR TITLE
Add `debug` and `clone` to Font and its types.

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -127,7 +127,7 @@ impl LineMetrics {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Glyph {
     pub v_lines: Vec<Line>,
     pub m_lines: Vec<Line>,
@@ -149,7 +149,7 @@ impl Default for Glyph {
 }
 
 /// Settings for controlling specific font and layout behavior.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct FontSettings {
     /// The default is true. This offsets glyphs relative to their position in their scaled
     /// bounding box. This is required for laying out glyphs correctly, but can be disabled to make
@@ -175,6 +175,7 @@ impl Default for FontSettings {
 }
 
 /// Represents a font. Fonts are immutable after creation and owns its own copy of the font data.
+#[derive(Debug, Clone)]
 pub struct Font {
     units_per_em: f32,
     glyphs: Vec<Glyph>,

--- a/src/font.rs
+++ b/src/font.rs
@@ -175,7 +175,7 @@ impl Default for FontSettings {
 }
 
 /// Represents a font. Fonts are immutable after creation and owns its own copy of the font data.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Font {
     units_per_em: f32,
     glyphs: Vec<Glyph>,
@@ -183,6 +183,17 @@ pub struct Font {
     horizontal_line_metrics: Option<LineMetrics>,
     vertical_line_metrics: Option<LineMetrics>,
     settings: FontSettings,
+}
+
+impl core::fmt::Debug for Font {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // when `finish_non_exhaustive` is stablized, we'll use it here
+        // but for now, this is fine
+        f.debug_struct("Font")
+            .field("units_per_em", &self.units_per_em)
+            .field("settings", &self.settings)
+            .finish()
+    }
 }
 
 /// Converts a ttf-parser FaceParsingError into a string.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,24 @@
 //! Fontdue is a font parser, rasterizer, and layout tool.
 //!
 //! This is a #![no_std] crate, but still requires the alloc crate.
-
 #![no_std]
 #![allow(dead_code)]
+#![allow(
+    clippy::excessive_precision,
+    clippy::approx_constant,
+    clippy::float_cmp,
+    clippy::needless_bool,
+    clippy::upper_case_acronyms,
+    clippy::many_single_char_names,
+    clippy::wildcard_in_or_patterns,
+    clippy::needless_return,
+    clippy::transmute_int_to_float,
+    clippy::transmute_float_to_int,
+    clippy::ptr_arg,
+    clippy::transmute_ptr_to_ptr,
+    clippy::let_and_return,
+    clippy::redundant_slicing,
+)]
 
 extern crate alloc;
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -225,7 +225,7 @@ impl Point {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Line {
     /// X0, Y0, X1, Y1.
     pub coords: f32x4,

--- a/src/platform/simd_core.rs
+++ b/src/platform/simd_core.rs
@@ -4,7 +4,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct f32x4 {
     x0: f32,
     x1: f32,

--- a/src/platform/simd_x86.rs
+++ b/src/platform/simd_x86.rs
@@ -7,7 +7,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
 pub struct f32x4(__m128);
 


### PR DESCRIPTION
This ended up effecting more types than I initially anticipated, which theoretically has the most minor of effects of compiles times,
or binary size, depending on if the impls are used by users.

However, it's just difficult to integrate `Font` into a larger game engine which assumes
that assets will implement Debug.