### PR TITLE
Microoptimization: Make some functions const

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -168,7 +168,7 @@ pub struct TextStyle<'a, U: Copy + Clone = ()> {
 }
 
 impl<'a> TextStyle<'a> {
-    pub fn new(text: &'a str, px: f32, font_index: usize) -> TextStyle<'a> {
+    pub const fn new(text: &'a str, px: f32, font_index: usize) -> TextStyle<'a> {
         TextStyle {
             text,
             px,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -168,7 +168,7 @@ pub struct TextStyle<'a, U: Copy + Clone = ()> {
 }
 
 impl<'a> TextStyle<'a> {
-    pub const fn new(text: &'a str, px: f32, font_index: usize) -> TextStyle<'a> {
+    pub fn new(text: &'a str, px: f32, font_index: usize) -> TextStyle<'a> {
         TextStyle {
             text,
             px,

--- a/src/math.rs
+++ b/src/math.rs
@@ -35,7 +35,7 @@ struct CubeCurve {
 }
 
 impl CubeCurve {
-    fn new(a: Point, b: Point, c: Point, d: Point) -> CubeCurve {
+    const fn new(a: Point, b: Point, c: Point, d: Point) -> CubeCurve {
         CubeCurve {
             a,
             b,
@@ -198,7 +198,7 @@ impl Default for Point {
 }
 
 impl Point {
-    pub fn new(x: f32, y: f32) -> Point {
+    pub const fn new(x: f32, y: f32) -> Point {
         Point {
             x,
             y,
@@ -330,7 +330,7 @@ struct Segment {
 }
 
 impl Segment {
-    fn new(a: Point, at: f32, c: Point, ct: f32) -> Segment {
+    const fn new(a: Point, at: f32, c: Point, ct: f32) -> Segment {
         Segment {
             a,
             at,

--- a/src/platform/simd_core.rs
+++ b/src/platform/simd_core.rs
@@ -51,18 +51,18 @@ impl f32x4 {
     }
 
     #[inline(always)]
-    pub fn copied(self) -> (f32, f32, f32, f32) {
+    pub const fn copied(self) -> (f32, f32, f32, f32) {
         (self.x0, self.x1, self.x2, self.x3)
     }
 
     #[inline(always)]
-    pub const fn trunc(self) -> Self {
+    pub fn trunc(self) -> Self {
         use super::trunc;
         Self::new(trunc(self.x0), trunc(self.x1), trunc(self.x2), trunc(self.x3))
     }
 
     #[inline(always)]
-    pub const fn sqrt(self) -> Self {
+    pub fn sqrt(self) -> Self {
         use super::sqrt;
         Self::new(sqrt(self.x0), sqrt(self.x1), sqrt(self.x2), sqrt(self.x3))
     }

--- a/src/platform/simd_core.rs
+++ b/src/platform/simd_core.rs
@@ -56,13 +56,13 @@ impl f32x4 {
     }
 
     #[inline(always)]
-    pub fn trunc(self) -> Self {
+    pub const fn trunc(self) -> Self {
         use super::trunc;
         Self::new(trunc(self.x0), trunc(self.x1), trunc(self.x2), trunc(self.x3))
     }
 
     #[inline(always)]
-    pub fn sqrt(self) -> Self {
+    pub const fn sqrt(self) -> Self {
         use super::sqrt;
         Self::new(sqrt(self.x0), sqrt(self.x1), sqrt(self.x2), sqrt(self.x3))
     }

--- a/src/table/kern.rs
+++ b/src/table/kern.rs
@@ -31,13 +31,13 @@ struct Coverage {
 }
 
 impl Coverage {
-    pub fn aat(cov: u8) -> Coverage {
+    pub const fn aat(cov: u8) -> Coverage {
         Coverage {
             is_horizontal: cov & 0x80 != 0x80,
         }
     }
 
-    pub fn ot(cov: u8) -> Coverage {
+    pub const fn ot(cov: u8) -> Coverage {
         Coverage {
             is_horizontal: cov & 0x01 == 0x01,
         }

--- a/src/table/parse.rs
+++ b/src/table/parse.rs
@@ -59,7 +59,7 @@ pub struct Stream<'a> {
 }
 
 impl<'a> Stream<'a> {
-    pub fn new(bytes: &'a [u8]) -> Stream<'a> {
+    pub const fn new(bytes: &'a [u8]) -> Stream<'a> {
         Stream {
             bytes,
             offset: 0,
@@ -74,7 +74,7 @@ impl<'a> Stream<'a> {
     }
 
     #[inline]
-    pub fn offset(&self) -> usize {
+    pub const fn offset(&self) -> usize {
         self.offset
     }
 


### PR DESCRIPTION
Have marked a few functions as `const`, if that is possible in the stable version. 

So this does not include functions that contain floating point arithmetic or a `mut` reference.

## `criterion` Benchmarks

### Before (Branch `master`)

```
layout/fontdue/100      time:   [3.9368 us 3.9979 us 4.0702 us]
Found 14 outliers among 250 measurements (5.60%)
  10 (4.00%) high mild
  4 (1.60%) high severe
layout/fontdue/500      time:   [20.980 us 21.243 us 21.535 us]
Found 20 outliers among 250 measurements (8.00%)
  14 (5.60%) high mild
  6 (2.40%) high severe
layout/fontdue/1000     time:   [42.722 us 43.300 us 43.956 us]
Found 27 outliers among 250 measurements (10.80%)
  12 (4.80%) high mild
  15 (6.00%) high severelayout/glyph_brush_layout/100
                        time:   [14.262 us 14.453 us 14.680 us]
Found 16 outliers among 250 measurements (6.40%)
  9 (3.60%) high mild
  7 (2.80%) high severe
layout/glyph_brush_layout/500
                        time:   [74.289 us 75.880 us 77.730 us]
Found 10 outliers among 250 measurements (4.00%)
  7 (2.80%) high mild
  3 (1.20%) high severe
Benchmarking layout/glyph_brush_layout/1000: Warming up for 3.0000 s
Warning: Unable to complete 250 samples in 4.0s. You may wish to increase target time to 4.6s, enable flat sampling, or reduce sample count to 160.
layout/glyph_brush_layout/1000
                        time:   [144.82 us 147.18 us 149.85 us]
Found 27 outliers among 250 measurements (10.80%)
  16 (6.40%) high mild
  11 (4.40%) high severe     Running unittests (target\release\deps\load-1ebd4c7446ed2dd1.exe)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.Gnuplot not found, using plotters backend
load/rusttype roboto    time:   [894.43 ns 909.01 ns 924.52 ns]
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe
load/ab_glyph roboto    time:   [1.0128 us 1.0385 us 1.0705 us]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
load/fontdue roboto     time:   [4.1027 ms 4.1663 ms 4.2406 ms]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe     Running unittests (target\release\deps\rasterize-6f6795b8152ccfd3.exe)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.Gnuplot not found, using plotters backend
rasterize/rusttype truetype 10px
                        time:   [52.563 us 53.613 us 54.892 us]
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
rasterize/rusttype truetype 20px
                        time:   [70.946 us 71.995 us 73.158 us]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
rasterize/rusttype truetype 40px
                        time:   [121.94 us 123.44 us 125.13 us]
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
rasterize/rusttype truetype 80px
                        time:   [254.45 us 258.14 us 262.78 us]
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
rasterize/rusttype truetype 160px
                        time:   [736.76 us 743.05 us 749.93 us]
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe
Benchmarking rasterize/rusttype truetype 200px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 5.5s, enable flat sampling, or reduce sample count to 60.
rasterize/rusttype truetype 200px
                        time:   [1.0651 ms 1.0735 ms 1.0841 ms]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
rasterize/rusttype opentype 10px
                        time:   [73.679 us 75.298 us 77.094 us]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
rasterize/rusttype opentype 20px
                        time:   [92.924 us 94.812 us 96.898 us]
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe
rasterize/rusttype opentype 40px
                        time:   [144.18 us 147.56 us 151.42 us]
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
rasterize/rusttype opentype 80px
                        time:   [287.16 us 292.25 us 298.09 us]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
Benchmarking rasterize/rusttype opentype 160px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 4.0s, enable flat sampling, or reduce sample count to 70.
rasterize/rusttype opentype 160px
                        time:   [781.97 us 791.54 us 802.82 us]
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
Benchmarking rasterize/rusttype opentype 200px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 5.8s, enable flat sampling, or reduce sample count to 50.
rasterize/rusttype opentype 200px
                        time:   [1.1246 ms 1.1375 ms 1.1534 ms]
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
rasterize/ab_glyph truetype 10px
                        time:   [70.340 us 71.803 us 73.616 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
rasterize/ab_glyph truetype 20px
                        time:   [88.384 us 89.413 us 90.523 us]
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
rasterize/ab_glyph truetype 40px
                        time:   [142.69 us 145.48 us 148.57 us]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
rasterize/ab_glyph truetype 80px
                        time:   [282.32 us 287.58 us 294.43 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
rasterize/ab_glyph truetype 160px
                        time:   [769.58 us 778.66 us 788.26 us]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking rasterize/ab_glyph truetype 200px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 5.7s, enable flat sampling, or reduce sample count to 50.
rasterize/ab_glyph truetype 200px
                        time:   [1.0970 ms 1.1072 ms 1.1189 ms]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
rasterize/ab_glyph opentype 10px
                        time:   [90.433 us 93.300 us 96.781 us]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
rasterize/ab_glyph opentype 20px
                        time:   [83.210 us 84.901 us 87.019 us]
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
rasterize/ab_glyph opentype 40px
                        time:   [135.41 us 137.98 us 140.95 us]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
rasterize/ab_glyph opentype 80px
                        time:   [279.60 us 284.92 us 291.71 us]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
rasterize/ab_glyph opentype 160px
                        time:   [774.97 us 782.57 us 791.16 us]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
Benchmarking rasterize/ab_glyph opentype 200px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 5.7s, enable flat sampling, or reduce sample count to 50.
rasterize/ab_glyph opentype 200px
                        time:   [1.1276 ms 1.1442 ms 1.1628 ms]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
rasterize/fontdue truetype 10px
                        time:   [13.000 us 13.315 us 13.692 us]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
rasterize/fontdue truetype 20px
                        time:   [24.334 us 24.611 us 24.923 us]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
rasterize/fontdue truetype 40px
                        time:   [26.627 us 27.122 us 27.716 us]
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
rasterize/fontdue truetype 80px
                        time:   [57.133 us 58.759 us 60.594 us]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
rasterize/fontdue truetype 160px
                        time:   [165.12 us 171.35 us 178.09 us]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
rasterize/fontdue truetype 200px
                        time:   [220.03 us 224.26 us 228.85 us]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
rasterize/fontdue opentype 10px
                        time:   [14.551 us 14.901 us 15.325 us]
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
rasterize/fontdue opentype 20px
                        time:   [17.753 us 18.219 us 18.799 us]
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
rasterize/fontdue opentype 40px
                        time:   [30.263 us 31.043 us 31.994 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
rasterize/fontdue opentype 80px
                        time:   [53.996 us 55.609 us 57.353 us]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
rasterize/fontdue opentype 160px
                        time:   [165.43 us 171.82 us 178.74 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
rasterize/fontdue opentype 200px
                        time:   [206.67 us 210.05 us 213.75 us]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```

### After (Branch `code-optimization`)
```
layout/fontdue/100      time:   [4.3643 us 4.4218 us 4.4931 us]
Found 29 outliers among 250 measurements (11.60%)
  16 (6.40%) high mild
  13 (5.20%) high severe
layout/fontdue/500      time:   [23.136 us 23.396 us 23.681 us]
Found 18 outliers among 250 measurements (7.20%)
  12 (4.80%) high mild
  6 (2.40%) high severe
layout/fontdue/1000     time:   [46.804 us 47.228 us 47.713 us]
Found 19 outliers among 250 measurements (7.60%)
  15 (6.00%) high mild
  4 (1.60%) high severelayout/glyph_brush_layout/100
                        time:   [14.549 us 14.788 us 15.061 us]
Found 31 outliers among 250 measurements (12.40%)
  15 (6.00%) high mild
  16 (6.40%) high severe
layout/glyph_brush_layout/500
                        time:   [73.153 us 73.955 us 74.840 us]
Found 21 outliers among 250 measurements (8.40%)
  13 (5.20%) high mild
  8 (3.20%) high severe
Benchmarking layout/glyph_brush_layout/1000: Warming up for 3.0000 s
Warning: Unable to complete 250 samples in 4.0s. You may wish to increase target time to 4.7s, enable flat sampling, or reduce sample count to 160.
layout/glyph_brush_layout/1000
                        time:   [145.95 us 148.79 us 152.17 us]
Found 31 outliers among 250 measurements (12.40%)
  9 (3.60%) high mild
  22 (8.80%) high severe     Running unittests (target\release\deps\load-1ebd4c7446ed2dd1.exe)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.Gnuplot not found, using plotters backend
load/rusttype roboto    time:   [881.63 ns 900.26 ns 922.12 ns]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
load/ab_glyph roboto    time:   [990.41 ns 1.0091 us 1.0316 us]
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
load/fontdue roboto     time:   [4.4020 ms 4.4644 ms 4.5320 ms]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe     Running unittests (target\release\deps\rasterize-6f6795b8152ccfd3.exe)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.Gnuplot not found, using plotters backend
rasterize/rusttype truetype 10px
                        time:   [51.405 us 52.240 us 53.267 us]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
rasterize/rusttype truetype 20px
                        time:   [71.044 us 71.931 us 72.982 us]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
rasterize/rusttype truetype 40px
                        time:   [125.07 us 127.42 us 130.69 us]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
rasterize/rusttype truetype 80px
                        time:   [256.21 us 259.25 us 263.01 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
rasterize/rusttype truetype 160px
                        time:   [734.03 us 738.59 us 743.83 us]
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
Benchmarking rasterize/rusttype truetype 200px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 5.4s, enable flat sampling, or reduce sample count to 60.
rasterize/rusttype truetype 200px
                        time:   [1.0666 ms 1.0737 ms 1.0818 ms]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
rasterize/rusttype opentype 10px
                        time:   [72.672 us 74.957 us 77.553 us]
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe
rasterize/rusttype opentype 20px
                        time:   [92.580 us 93.683 us 94.929 us]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
rasterize/rusttype opentype 40px
                        time:   [143.39 us 147.03 us 151.34 us]
Found 13 outliers among 100 measurements (13.00%)
  9 (9.00%) high mild
  4 (4.00%) high severe
rasterize/rusttype opentype 80px
                        time:   [287.46 us 291.36 us 295.52 us]
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe
rasterize/rusttype opentype 160px
                        time:   [778.09 us 785.46 us 794.68 us]
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
Benchmarking rasterize/rusttype opentype 200px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 5.7s, enable flat sampling, or reduce sample count to 50.
rasterize/rusttype opentype 200px
                        time:   [1.1217 ms 1.1321 ms 1.1455 ms]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
rasterize/ab_glyph truetype 10px
                        time:   [70.629 us 72.246 us 74.203 us]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
rasterize/ab_glyph truetype 20px
                        time:   [90.244 us 92.038 us 94.215 us]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
rasterize/ab_glyph truetype 40px
                        time:   [140.04 us 141.98 us 144.43 us]
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe
rasterize/ab_glyph truetype 80px
                        time:   [282.09 us 285.94 us 290.44 us]
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
rasterize/ab_glyph truetype 160px
                        time:   [747.87 us 753.43 us 759.84 us]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
Benchmarking rasterize/ab_glyph truetype 200px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 5.5s, enable flat sampling, or reduce sample count to 50.
rasterize/ab_glyph truetype 200px
                        time:   [1.0902 ms 1.0992 ms 1.1087 ms]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
rasterize/ab_glyph opentype 10px
                        time:   [63.984 us 65.677 us 67.730 us]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
rasterize/ab_glyph opentype 20px
                        time:   [83.610 us 85.011 us 86.719 us]
Found 13 outliers among 100 measurements (13.00%)
  9 (9.00%) high mild
  4 (4.00%) high severe
rasterize/ab_glyph opentype 40px
                        time:   [132.84 us 134.58 us 136.66 us]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
rasterize/ab_glyph opentype 80px
                        time:   [284.74 us 292.98 us 302.85 us]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
rasterize/ab_glyph opentype 160px
                        time:   [765.39 us 770.66 us 776.43 us]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
Benchmarking rasterize/ab_glyph opentype 200px: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 4.0s. You may wish to increase target time to 5.7s, enable flat sampling, or reduce sample count to 50.
rasterize/ab_glyph opentype 200px
                        time:   [1.1085 ms 1.1182 ms 1.1300 ms]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
rasterize/fontdue truetype 10px
                        time:   [35.574 us 36.151 us 36.750 us]
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
rasterize/fontdue truetype 20px
                        time:   [20.003 us 20.317 us 20.706 us]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
rasterize/fontdue truetype 40px
                        time:   [27.129 us 27.646 us 28.238 us]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
rasterize/fontdue truetype 80px
                        time:   [60.512 us 62.464 us 64.809 us]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe
rasterize/fontdue truetype 160px
                        time:   [152.80 us 155.76 us 158.95 us]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
rasterize/fontdue truetype 200px
                        time:   [213.14 us 216.81 us 220.91 us]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
rasterize/fontdue opentype 10px
                        time:   [11.939 us 12.163 us 12.434 us]
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
rasterize/fontdue opentype 20px
                        time:   [17.800 us 18.161 us 18.581 us]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
rasterize/fontdue opentype 40px
                        time:   [29.286 us 29.723 us 30.208 us]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
rasterize/fontdue opentype 80px
                        time:   [57.324 us 58.598 us 60.133 us]
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
rasterize/fontdue opentype 160px
                        time:   [149.25 us 152.62 us 156.81 us]
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
rasterize/fontdue opentype 200px
                        time:   [207.22 us 212.67 us 219.20 us]
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
```

### Comparison