### PR TITLE
Parallelize glyph loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ maintenance = { status = "experimental" }
 freetype_benchmark = ["freetype-rs"]
 # Enable this flag to disable SIMD usage on x86/x86_64 platforms.
 disable_simd = []
+parallel = ["rayon", "hashbrown/rayon"]
 
 [dependencies]
 ttf-parser = { version = "0.12", default-features = false }
 hashbrown = "0.11"
+rayon = { version = "1.5.1", optional = true }
 
 # This is a dev-dependency, but those cannot be optional, so it's included here and not built by
 # default.


### PR DESCRIPTION
Speed up `load` bench 5 times fast(on my 5800X machine) even faster than other libraries

![20211111161418](https://user-images.githubusercontent.com/14910534/141255779-68baf137-0a35-4160-ba1a-1c23b452ad69.png)
![20211111161515](https://user-images.githubusercontent.com/14910534/141255786-e7e6967b-af1d-4e61-9d95-edaad52ec167.png)
