### PR TITLE
Refactor(layout): relax trait bounds for various `impl` blocks

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -57,7 +57,7 @@ pub enum CoordinateSystem {
 
 /// Settings to configure how text layout is constrained. Text layout is considered best effort and
 /// layout may violate the constraints defined here if they prevent text from being laid out.
-#[derive(Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct LayoutSettings {
     /// The leftmost boundary of the text region.
     pub x: f32,
@@ -378,6 +378,11 @@ impl<U> Layout<U> {
             Some(&self.line_metrics)
         }
     }
+
+    /// Gets the currently laid out glyphs.
+    pub fn glyphs(&self) -> &Vec<GlyphPosition<U>> {
+        &self.output
+    }
 }
 
 impl<U: Clone + Copy> Layout<U> {
@@ -525,10 +530,5 @@ impl<U: Clone + Copy> Layout<U> {
             }
             baseline_y -= dir * (line.max_new_line_size - line.max_ascent);
         }
-    }
-
-    /// Gets the currently laid out glyphs.
-    pub fn glyphs(&self) -> &Vec<GlyphPosition<U>> {
-        &self.output
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -482,7 +482,7 @@ impl<U: Clone + Copy> Layout<U> {
                 width: metrics.width,
                 height: metrics.height,
                 char_data,
-                user_data: style.user_data.clone(),
+                user_data: style.user_data,
             });
             self.current_pos += advance;
         }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -183,7 +183,7 @@ impl<'a> TextStyle<'a, ()> {
 
 impl<'a, U> TextStyle<'a, U> {
     pub fn with_user_data(text: &'a str, px: f32, font_index: usize, user_data: U) -> Self {
-        TextStyle {
+        Self {
             text,
             px,
             font_index,
@@ -280,8 +280,8 @@ pub struct Layout<U = ()> {
 impl<U> Layout<U> {
     /// Creates a layout instance. This requires the direction that the Y coordinate increases in.
     /// Layout needs to be aware of your coordinate system to place the glyphs correctly.
-    pub fn new(coordinate_system: CoordinateSystem) -> Layout<U> {
-        let mut layout = Layout {
+    pub fn new(coordinate_system: CoordinateSystem) -> Self {
+        let mut layout = Self {
             flip: coordinate_system == CoordinateSystem::PositiveYDown,
             x: 0.0,
             y: 0.0,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -193,7 +193,7 @@ impl<'a, U> TextStyle<'a, U> {
 }
 
 /// Metrics about a positioned line.
-#[derive(Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone)]
 pub struct LinePosition {
     /// The y coordinate of the baseline of this line, in pixels.
     pub baseline_y: f32,
@@ -219,22 +219,6 @@ pub struct LinePosition {
     pub glyph_end: usize,
     /// The x offset into the first layout pass.
     tracking_x: f32,
-}
-
-impl Default for LinePosition {
-    fn default() -> Self {
-        LinePosition {
-            baseline_y: 0.0,
-            padding: 0.0,
-            max_ascent: 0.0,
-            min_descent: 0.0,
-            max_line_gap: 0.0,
-            max_new_line_size: 0.0,
-            glyph_start: 0,
-            glyph_end: 0,
-            tracking_x: 0.0,
-        }
-    }
 }
 
 /// Text layout requires a small amount of heap usage which is contained in the Layout struct. This

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -385,7 +385,7 @@ impl<U> Layout<U> {
     }
 }
 
-impl<U: Clone + Copy> Layout<U> {
+impl<U: Copy> Layout<U> {
     /// Performs layout for text horizontally, and wrapping vertically. This makes a best effort
     /// attempt at laying out the text defined in the given styles with the provided layout
     /// settings. Text may overflow out of the bounds defined in the layout settings and it's up

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -170,7 +170,7 @@ pub struct TextStyle<'a, U = ()> {
     pub user_data: U,
 }
 
-impl<'a> TextStyle<'a, ()> {
+impl<'a> TextStyle<'a> {
     pub fn new(text: &'a str, px: f32, font_index: usize) -> Self {
         Self {
             text,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -57,7 +57,7 @@ pub enum CoordinateSystem {
 
 /// Settings to configure how text layout is constrained. Text layout is considered best effort and
 /// layout may violate the constraints defined here if they prevent text from being laid out.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct LayoutSettings {
     /// The leftmost boundary of the text region.
     pub x: f32,
@@ -396,7 +396,7 @@ impl<U> Layout<U> {
     }
 }
 
-impl<U: Copy> Layout<U> {
+impl<U: Clone + Copy> Layout<U> {
     /// Performs layout for text horizontally, and wrapping vertically. This makes a best effort
     /// attempt at laying out the text defined in the given styles with the provided layout
     /// settings. Text may overflow out of the bounds defined in the layout settings and it's up
@@ -498,7 +498,7 @@ impl<U: Copy> Layout<U> {
                 width: metrics.width,
                 height: metrics.height,
                 char_data,
-                user_data: style.user_data,
+                user_data: style.user_data.clone(),
             });
             self.current_pos += advance;
         }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -129,7 +129,7 @@ impl Eq for GlyphRasterConfig {}
 
 /// A positioned scaled glyph.
 #[derive(Debug, Copy, Clone)]
-pub struct GlyphPosition<U> {
+pub struct GlyphPosition<U = ()> {
     /// Hashable key that can be used to uniquely identify a rasterized glyph.
     pub key: GlyphRasterConfig,
     /// The index of the font used to generate this glyph position.
@@ -159,7 +159,7 @@ pub struct GlyphPosition<U> {
 }
 
 /// A style description for a segment of text.
-pub struct TextStyle<'a, U> {
+pub struct TextStyle<'a, U = ()> {
     /// The text to layout.
     pub text: &'a str,
     /// The scale of the text in pixel units. The units of the scale are pixels per Em unit.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -129,7 +129,7 @@ impl Eq for GlyphRasterConfig {}
 
 /// A positioned scaled glyph.
 #[derive(Debug, Copy, Clone)]
-pub struct GlyphPosition<U: Copy + Clone = ()> {
+pub struct GlyphPosition<U> {
     /// Hashable key that can be used to uniquely identify a rasterized glyph.
     pub key: GlyphRasterConfig,
     /// The index of the font used to generate this glyph position.
@@ -159,7 +159,7 @@ pub struct GlyphPosition<U: Copy + Clone = ()> {
 }
 
 /// A style description for a segment of text.
-pub struct TextStyle<'a, U: Copy + Clone = ()> {
+pub struct TextStyle<'a, U> {
     /// The text to layout.
     pub text: &'a str,
     /// The scale of the text in pixel units. The units of the scale are pixels per Em unit.
@@ -170,9 +170,9 @@ pub struct TextStyle<'a, U: Copy + Clone = ()> {
     pub user_data: U,
 }
 
-impl<'a> TextStyle<'a> {
-    pub fn new(text: &'a str, px: f32, font_index: usize) -> TextStyle<'a> {
-        TextStyle {
+impl<'a> TextStyle<'a, ()> {
+    pub fn new(text: &'a str, px: f32, font_index: usize) -> Self {
+        Self {
             text,
             px,
             font_index,
@@ -181,8 +181,8 @@ impl<'a> TextStyle<'a> {
     }
 }
 
-impl<'a, U: Copy + Clone> TextStyle<'a, U> {
-    pub fn with_user_data(text: &'a str, px: f32, font_index: usize, user_data: U) -> TextStyle<'a, U> {
+impl<'a, U> TextStyle<'a, U> {
+    pub fn with_user_data(text: &'a str, px: f32, font_index: usize, user_data: U) -> Self {
         TextStyle {
             text,
             px,
@@ -240,7 +240,7 @@ impl Default for LinePosition {
 /// Text layout requires a small amount of heap usage which is contained in the Layout struct. This
 /// context is reused between layout calls. Reusing the Layout struct will greatly reduce memory
 /// allocations and is advisable for performance.
-pub struct Layout<U: Copy + Clone = ()> {
+pub struct Layout<U = ()> {
     /// Marks if layout should be performed as if the Y axis is flipped (Positive Y incrementing
     /// down instead of up).
     flip: bool,
@@ -293,7 +293,7 @@ pub struct Layout<U: Copy + Clone = ()> {
     start_pos: f32,
 }
 
-impl<'a, U: Copy + Clone> Layout<U> {
+impl<U> Layout<U> {
     /// Creates a layout instance. This requires the direction that the Y coordinate increases in.
     /// Layout needs to be aware of your coordinate system to place the glyphs correctly.
     pub fn new(coordinate_system: CoordinateSystem) -> Layout<U> {
@@ -387,14 +387,16 @@ impl<'a, U: Copy + Clone> Layout<U> {
     }
 
     /// Gets the currently positioned lines. If there are no lines positioned, this returns none.
-    pub fn lines(&'a self) -> Option<&'a Vec<LinePosition>> {
+    pub fn lines(&self) -> Option<&Vec<LinePosition>> {
         if self.glyphs.is_empty() {
             None
         } else {
             Some(&self.line_metrics)
         }
     }
+}
 
+impl<U: Copy> Layout<U> {
     /// Performs layout for text horizontally, and wrapping vertically. This makes a best effort
     /// attempt at laying out the text defined in the given styles with the provided layout
     /// settings. Text may overflow out of the bounds defined in the layout settings and it's up
@@ -542,7 +544,7 @@ impl<'a, U: Copy + Clone> Layout<U> {
     }
 
     /// Gets the currently laid out glyphs.
-    pub fn glyphs(&'a self) -> &'a Vec<GlyphPosition<U>> {
+    pub fn glyphs(&self) -> &Vec<GlyphPosition<U>> {
         &self.output
     }
 }


### PR DESCRIPTION
# Summary
Previously, the `layout` module enforced strict trait bounds on the underlying user data type—that is, `U: Copy + Clone`. This is not necessary for most of the methods of `Layout<U>`. In fact, only one method requires these strict bounds: `Layout::append`. Similarly, `Layout::glyphs` only requires `Clone`, not `Copy`. Hence, I have separated the methods into three `impl` blocks so that the bounds only apply where _absolutely_ necessary.

```rust
impl<U> Layout<U> {
    // General methods and getters that don't require `Clone`...
}

impl<U: Clone> Layout<U> {
    pub fn glyphs(...) { }
}

impl<U: Copy> Layout<U> {
    pub fn append(...) { }
}
```

# Breaking Changes
I noticed that some of the `struct`s in the `layout` module implement `Copy` despite being particularly "heavy" (in terms of memory footprint). I have taken the liberty to remove their `Copy` bounds because it is semantically problematic to assert that these `struct`s are "cheap to copy". Namely, this applies to `LayoutSettings`, `GlyphRasterConfig`, and `GlyphPosition`. Code that relies on the copy semantics now have to explicitly invoke `Clone::clone`.

Notably, this change allowed me to further relax the bounds on `Layout` to (1) be `Clone` if the `Layout::glyphs` method is needed and (2) be `Copy` if the `Layout::append` method is needed. However, it may be worth documenting that `Copy`-able types are preferable nevertheless.

If there are any issues with these changes, I'd be glad to address them. Thanks! 🎉