### PR TITLE
Fix: address various Clippy warnings

### DIFF
--- a/benches/load.rs
+++ b/benches/load.rs
@@ -2,7 +2,6 @@
 extern crate criterion;
 
 use criterion::{measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion};
-use fontdue;
 
 type SetupFunction = fn(&mut BenchmarkGroup<WallTime>, &str, &[u8]);
 

--- a/benches/rasterize.rs
+++ b/benches/rasterize.rs
@@ -2,7 +2,6 @@
 extern crate criterion;
 
 use criterion::{measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion};
-use fontdue;
 
 type SetupFunction = fn(&mut BenchmarkGroup<WallTime>, &str, &[u8], f32);
 

--- a/tests/modules/baseline_tests.rs
+++ b/tests/modules/baseline_tests.rs
@@ -43,10 +43,7 @@ fn record_local_baseline(font: &Font, name: &str, character_index: u16, size: f3
     if !Path::new(&reference_path).exists() || fs::read(reference_path).unwrap() != encoded {
         // only write out local bitmap when it doesn't match (this saves a lot of disk i/o time)
         fs::create_dir_all(Path::new(&local_path).parent()?).ok();
-        let err = fs::write(&local_path, encoded);
-        if err.is_err() {
-            assert!(false, "Unable to save file {}: {}", &local_path, err.unwrap_err());
-        }
+        fs::write(&local_path, encoded).unwrap();
     }
     None
 }
@@ -103,7 +100,7 @@ fn report_changed_baselines() {
     }
 
     assert!(
-        failures.len() == 0,
+        failures.is_empty(),
         "Baseline failures:
 {}
 

--- a/tests/modules/baseline_tests.rs
+++ b/tests/modules/baseline_tests.rs
@@ -43,7 +43,9 @@ fn record_local_baseline(font: &Font, name: &str, character_index: u16, size: f3
     if !Path::new(&reference_path).exists() || fs::read(reference_path).unwrap() != encoded {
         // only write out local bitmap when it doesn't match (this saves a lot of disk i/o time)
         fs::create_dir_all(Path::new(&local_path).parent()?).ok();
-        fs::write(&local_path, encoded).unwrap();
+        if let Err(err) = fs::write(&local_path, encoded) {
+            panic!("Unable to save file {}: {}", &local_path, err);
+        }
     }
     None
 }

--- a/tests/modules/letter_render_tests.rs
+++ b/tests/modules/letter_render_tests.rs
@@ -24,7 +24,7 @@ fn check_best_guess_rasterization(
         rendered_char,
         index
     );
-    if bitmap.len() > 0 {
+    if !bitmap.is_empty() {
         let mut visible = false;
         for x in bitmap {
             if x > 0 {


### PR DESCRIPTION
This PR simply runs `cargo clippy --fix` over the codebase. One of the tests did require manual re-formatting. I simply unwrapped the `Err` so that the test panics in case it is not possible to save a file.

Thanks! 🎉