### PR TITLE
partial fix for #98

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,10 @@
 #![allow(clippy::style)]
 #![allow(clippy::complexity)]
 
+// Partial fix for https://github.com/mooman219/fontdue/issues/98
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd", not(target_feature = "sse")))]
+compile_error!("on x86_64 the `simd` feature only compiles, if SSE is enabled!");
+
 extern crate alloc;
 
 mod font;


### PR DESCRIPTION
This is a partial fix for #98, that at least breaks builds early with a clear message if the crate gets compiled with softfloat/without sse etc!

![image](https://user-images.githubusercontent.com/5737016/149203021-379c3db0-9f1f-45e7-80dd-592815c9912b.png)
