### PR TITLE
Make `Font::from_bytes` take `impl AsRef<[u8]>`

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -233,10 +233,10 @@ fn convert_name(face: &Face) -> Option<String> {
 
 impl Font {
     /// Constructs a font from an array of bytes.
-    pub fn from_bytes<Data: Deref<Target = [u8]>>(data: Data, settings: FontSettings) -> FontResult<Font> {
-        let hash = crate::hash::hash(&data);
+    pub fn from_bytes(data: impl AsRef<[u8]>, settings: FontSettings) -> FontResult<Font> {
+        let hash = crate::hash::hash(data.as_ref());
 
-        let face = match Face::from_slice(&data, settings.collection_index) {
+        let face = match Face::from_slice(data.as_ref(), settings.collection_index) {
             Ok(f) => f,
             Err(e) => return Err(convert_error(e)),
         };


### PR DESCRIPTION
This is an API-breaking change, so I'm not sure if it's really worth it, but I think `impl AsRef<[u8]>` is a bit more conventional signature for taking byte slices than is `T: Deref<Target=[u8]>`.