### PR TITLE
Update hashbrown to fix no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ parallel = ["rayon", "hashbrown/rayon"]
 
 [dependencies]
 ttf-parser = { version = "0.15", default-features = false }
-hashbrown = "0.11"
+hashbrown = "0.13"
 rayon = { version = "1.5.1", optional = true }


### PR DESCRIPTION
Hi!

This small PR updates `hashbrown` and with that `ahash`.

The current version of `ahash` has the `runtime-rng` feature enabled by default, this breaks `no_std` in any platform that `getrandom` isn't available.

Cheers