### PR TITLE
Support Loading Ligature & Substitution Glyphs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ default = ["simd"]
 simd = []
 # Enable this flag to parallelize font loading using threads.
 parallel = ["rayon", "hashbrown/rayon"]
+# Enable this flag to load ligatures & substitutions on compatible fonts.
+# Only makes a difference when using indexed operations, e.g. `rasterize_indexed()`,
+# as singular chars do not have enough context to be substituted.
+gsub = ["ttf-parser/opentype-layout"]
 
 [dependencies]
 ttf-parser = { version = "0.15", default-features = false }

--- a/src/font.rs
+++ b/src/font.rs
@@ -266,6 +266,8 @@ impl Font {
                 })
             }
         }
+
+        // If the gsub table exists and the user needs it, add all of its glyphs to the glyphs we should load.
         #[cfg(feature = "gsub")]
         if let Some(subtable) = face.tables().gsub {
             use ttf_parser::gsub::SubstitutionSubtable;
@@ -302,35 +304,35 @@ impl Font {
                                     coverage: _,
                                     substitutes,
                                 } => {
-                                    substitutes.into_iter().for_each(|g| {
+                                    for g in substitutes {
                                         seen_mappings.insert(g.0);
-                                    });
+                                    }
                                 }
                             }
                         }
                         SubstitutionSubtable::Multiple(ms) => {
-                            ms.sequences.into_iter().for_each(|seq| {
-                                seq.substitutes.into_iter().for_each(|g| {
+                            for seq in ms.sequences {
+                                for g in seq.substitutes {
                                     seen_mappings.insert(g.0);
-                                })
-                            });
+                                }
+                            }
                         }
                         SubstitutionSubtable::Alternate(als) => {
-                            als.alternate_sets.into_iter().for_each(|al| {
-                                al.alternates.into_iter().for_each(|g| {
+                            for alt in als.alternate_sets {
+                                for g in alt.alternates {
                                     seen_mappings.insert(g.0);
-                                })
-                            });
+                                }
+                            }
                         }
                         SubstitutionSubtable::Ligature(ls) => ls.ligature_sets.into_iter().for_each(|ls| {
-                            ls.into_iter().for_each(|l| {
+                            for l in ls {
                                 seen_mappings.insert(l.glyph.0);
-                            })
+                            }
                         }),
                         SubstitutionSubtable::ReverseChainSingle(rcsl) => {
-                            rcsl.substitutes.into_iter().for_each(|g| {
+                            for g in rcsl.substitutes {
                                 seen_mappings.insert(g.0);
-                            })
+                            }
                         }
                         _ => {}
                     }


### PR DESCRIPTION
Adds an optional (off by default) feature that loads the glyphs for ligatures & substitutions.

This makes it so that glyphs that have been shaped by some other crate (allsorts, rustybuzz) to actually render if they formed a ligature or substitution.

Using the allsorts crate to shape Cascadia Code with ligatures:
Example without ligature loading (note that the ligatures, after being shaped, do not get rendered):
![image](https://github.com/mooman219/fontdue/assets/101683475/c603757e-7ad3-4e8a-80b1-254be4fb4cd6)
Example with:
![image](https://github.com/mooman219/fontdue/assets/101683475/c53b3360-8ed7-431b-8185-c07aa8b026d7)
