### PR TITLE
Make hashbrown optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,17 @@ exclude = ["dev/**"]
 maintenance = { status = "experimental" }
 
 [features]
-default = ["simd"]
+default = ["simd", "hashbrown"]
+# Enable this flag to use std::HashMap instead of hashbrown::HashMap
+std = []
 # Enable this flag to leverage SIMD usage on x86/x86_64 platforms.
 simd = []
 # Enable this flag to parallelize font loading using threads.
-parallel = ["rayon", "hashbrown/rayon"]
+parallel = ["rayon", "hashbrown", "hashbrown/rayon"]
 
 [dependencies]
 ttf-parser = { version = "0.20", default-features = false, features = [
     "opentype-layout",
 ] }
-hashbrown = "0.14"
+hashbrown = { version = "0.14", optional = true }
 rayon = { version = "1.5.1", optional = true }

--- a/src/font.rs
+++ b/src/font.rs
@@ -12,7 +12,10 @@ use core::hash::{Hash, Hasher};
 use core::mem;
 use core::num::NonZeroU16;
 use core::ops::Deref;
+#[cfg(feature = "hashbrown")]
 use hashbrown::{HashMap, HashSet};
+#[cfg(not(feature = "hashbrown"))]
+use std::collections::{HashMap, HashSet};
 use ttf_parser::{Face, FaceParsingError, GlyphId, Tag};
 
 #[cfg(feature = "parallel")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This is a no_std crate, but still requires the alloc crate.
 
-#![no_std]
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![allow(dead_code)]
 #![allow(clippy::style)]
 #![allow(clippy::complexity)]

--- a/src/table/gsub.rs
+++ b/src/table/gsub.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "hashbrown")]
 use hashbrown::HashSet;
+#[cfg(not(feature = "hashbrown"))]
+use std::collections::HashSet;
 use ttf_parser::Face;
 
 pub fn load_gsub(face: &Face, indices_to_load: &mut HashSet<u16>) {

--- a/src/table/kern.rs
+++ b/src/table/kern.rs
@@ -1,5 +1,8 @@
 use crate::table::parse::*;
+#[cfg(feature = "hashbrown")]
 use hashbrown::HashMap;
+#[cfg(not(feature = "hashbrown"))]
+use std::collections::HashMap;
 
 // Apple: https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6kern.html
 // Microsoft: https://docs.microsoft.com/en-us/typography/opentype/spec/kern


### PR DESCRIPTION
`hashbrown` became a fairly heavy dependency: 

```
├── fontdue v0.7.3
│   ├── hashbrown v0.13.2
│   │   └── ahash v0.8.11
│   │       ├── cfg-if v1.0.0
│   │       ├── once_cell v1.19.0
│   │       └── zerocopy v0.7.34
│   │           └── zerocopy-derive v0.7.34 (proc-macro)
│   │               ├── proc-macro2 v1.0.82
│   │               │   └── unicode-ident v1.0.12
│   │               ├── quote v1.0.36
│   │               │   └── proc-macro2 v1.0.82
│   │               │       └── unicode-ident v1.0.12
│   │               └── syn v2.0.63
│   │                   ├── proc-macro2 v1.0.82
│   │                   │   └── unicode-ident v1.0.12
│   │                   ├── quote v1.0.36
│   │                   │   └── proc-macro2 v1.0.82
│   │                   │       └── unicode-ident v1.0.12
│   │                   └── unicode-ident v1.0.12
│   │       [build-dependencies]
│   │       └── version_check v0.9.4
│   └── ttf-parser v0.15.2
```

`hashbrown` had the same problem in the past: https://github.com/tkaitchuck/aHash/pull/18), I believe it might be fixed again (I should do a PR there too!). 

But so far - it would be nice to just fallback to std. 