### PR TITLE
Fix typos

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -410,7 +410,7 @@ impl Font {
         self.horizontal_kern_indexed(self.lookup_glyph_index(left), self.lookup_glyph_index(right), px)
     }
 
-    /// Retrieves the horizontal scaled kerning value for two adjacent glyph indicies.
+    /// Retrieves the horizontal scaled kerning value for two adjacent glyph indices.
     /// # Arguments
     ///
     /// * `left` - The glyph index on the left hand side of the pairing.

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -21,7 +21,7 @@
 //! not use this hash for cryptographic purproses.  Furthermore, this hashing algorithm was
 //! not designed to prevent any attacks for determining collisions which could be used to
 //! potentially cause quadratic behavior in `HashMap`s.  So it is not recommended to expose
-//! this hash in places where collissions or DDOS attacks may be a concern.
+//! this hash in places where collisions or DDOS attacks may be a concern.
 
 use core::convert::TryInto;
 use core::ops::BitXor;

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -179,7 +179,7 @@ impl CharacterData {
         }
     }
 
-    /// A heuristic for if the glpyh this was classified from should be rasterized. Missing glyphs,
+    /// A heuristic for if the glyph this was classified from should be rasterized. Missing glyphs,
     /// whitespace, and control characters will return false.
     pub fn rasterize(&self) -> bool {
         self.bits == 0


### PR DESCRIPTION
Found via `codespell -L crate,als,ot,varius,habitant`