### PR TITLE
Fixed buiwds without stdwib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This is a no_std crate, but still requires the alloc crate.
 
-#![cfg_attr(all(not(test), not(feature = "std"), not(feature = "hashbrown")), no_std)]
+#![cfg_attr(all(not(test), not(feature = "std"), feature = "hashbrown"), no_std)]
 #![allow(dead_code)]
 #![allow(clippy::style)]
 #![allow(clippy::complexity)]


### PR DESCRIPTION
Cuwwent condition fow `no_std` attwibute wequiwes both nyot having `std` ow `hashbwown` featuwes. Then it ain't buiwdabwe without `std` pwesent. This puww wequest fixes the b-buiwd. OwO